### PR TITLE
Add .hpp files to C/C++ files.

### DIFF
--- a/licenseheaders.py
+++ b/licenseheaders.py
@@ -106,7 +106,7 @@ typeSettings = {
         "headerLineSuffix": None            ## inserted after each header text line, but before the new line
     },
     "c": {
-        "extensions": [".c",".cc",".cpp","c++",".h"],
+        "extensions": [".c",".cc",".cpp","c++",".h",".hpp"],
         "keepFirst": None,
         "blockCommentStartPattern": re.compile(r'^\s*/\*'),
         "blockCommentEndPattern": re.compile(r'\*/\s*$'),


### PR DESCRIPTION
Add `.hpp` file extension to C/C++ files. This is a very common file extension, especially in header-only libraries where the declarations and the definitions are separated in two distinct files.