### PR TITLE
New feature "additional-extensions" to not only support built-in file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,21 @@ the supported types (see below) in or below some directory.
 ## Usage
 
 ```
-usage: licenseheaders [-h] [-V] [-v] [-d DIR] [-t TMPL] [-y YEARS] [-o OWNER]
-                      [-n PROJECTNAME] [-u PROJECTURL] [--enc ENCODING]
-                      [--safesubst]
+usage: licenseheaders [-h] [-V] [-v] [-d DIR] [-b] [-t TMPL] [-y YEARS]
+                         [-o OWNER] [-n PROJECTNAME] [-u PROJECTURL]
+                         [--enc ENCODING] [--safesubst] [-D]
+                         [--additional-extensions ADDITIONAL_EXTENSIONS [ADDITIONAL_EXTENSIONS ...]]
 
 Python license header updater
 
 optional arguments:
   -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
-  -v, --verbose         increases log verbosity (can be specified multiple
-                        times)
+  -v, --verbose         increases log verbosity (can be specified 1 to 3
+                        times, default shows errors only)
   -d DIR, --dir DIR     The directory to recursively process (default: .).
-  -b                    Backup all files that get modified to a copy with added extension .bak
+  -b                    Back up all files which get changed to a copy with
+                        .bak added to the name
   -t TMPL, --tmpl TMPL  Template name or file to use.
   -y YEARS, --years YEARS
                         Year or year range to use.
@@ -34,6 +36,12 @@ optional arguments:
   --enc ENCODING        Encoding of program files (default: utf-8)
   --safesubst           Do not raise error if template variables cannot be
                         substituted.
+  -D                    Enable debug messages (same as -v -v -v)
+  --additional-extensions ADDITIONAL_EXTENSIONS [ADDITIONAL_EXTENSIONS ...]
+                        Provide a comma-separated list of additional file
+                        extensions as value for a specified language as key,
+                        each with a leading dot and no whitespace (default:
+                        None).
 
 Known extensions: ['.java', '.scala', '.groovy', '.jape', '.js', '.sh', '.csh', '.py', '.pl', '.pl', '.py', '.xml', '.sql', '.c', '.cc', '.cpp', 'c++', '.h', '.hpp', '.rb', '.cs', '.vb', '.erl', '.src', '.config', '.schema']
 
@@ -50,9 +58,12 @@ Examples:
   licenseheaders -y 2012-2015
   # only update the year in all existing headers, process the given directory
   licenseheaders -y 2012-2015 -d /dir/where/to/start/
+  # apply copyright headers to files specified by their language family + file extensions
+  licenseheaders -y 2012-2015 -d /dir/where/to/start/ --additional-extensions python=.j2
+  licenseheaders -y 2012-2015 -d /dir/where/to/start/ --additional-extensions python=.j2,.tpl script=.txt
 ```
 
-If licenseheaders is installed as a package (from pypi for instance), one can interact with it as a command line tool:
+If *licenseheaders* is installed as a package (from pypi for instance), one can interact with it as a command line tool:
 
 ```
 python -m licenseheaders -t lgpl3 -c "Eager Hacker"
@@ -88,6 +99,10 @@ sources:
 
 
 ## Supported file types and how they are processed
+
+*NOTE:* You can provide additional file extensions with `--additional-extensions` cli argument.
+Note that file extensions which contain multiple dots, e.g. ".py.j2", are not yet supported,
+use ".j2" at the moment instead.
 
 java:
 - extensions .java, .scala, .groovy, .jape, .js

--- a/licenseheaders.py
+++ b/licenseheaders.py
@@ -23,21 +23,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import argparse
+import fnmatch
+import logging
 import os
 import sys
-import logging
-import argparse
-import regex as re
-import fnmatch
-from string import Template
 from shutil import copyfile
+from string import Template
+
+import regex as re
 
 __version__ = '0.7'
 __author__ = 'Johann Petrak'
 __license__ = 'MIT'
 
 LOGGER = logging.getLogger(__name__)
-
 
 # for each processing type, the detailed settings of how to process files of that type
 typeSettings = {
@@ -175,8 +175,9 @@ typeSettings = {
     }
 }
 
-yearsPattern = re.compile(r"(?<=Copyright\s*(?:\(\s*[Cc©]\s*\)\s*))?([0-9][0-9][0-9][0-9](?:-[0-9][0-9]?[0-9]?[0-9]?)?)",
-                          re.IGNORECASE)
+yearsPattern = re.compile(
+    r"(?<=Copyright\s*(?:\(\s*[Cc©]\s*\)\s*))?([0-9][0-9][0-9][0-9](?:-[0-9][0-9]?[0-9]?[0-9]?)?)",
+    re.IGNORECASE)
 licensePattern = re.compile(r"license", re.IGNORECASE)
 emptyPattern = re.compile(r'^\s*$')
 
@@ -220,10 +221,10 @@ def parse_command_line(argv):
     parser.add_argument("-v", "--verbose", dest="verbose_count",
                         action="count", default=0,
                         help="increases log verbosity (can be specified "
-                        "1 to 3 times, default shows errors only)")
+                             "1 to 3 times, default shows errors only)")
     parser.add_argument("-d", "--dir", dest="dir", default=default_dir,
                         help="The directory to recursively process (default: {}).".format(default_dir))
-    parser.add_argument("-b", action="store_true", 
+    parser.add_argument("-b", action="store_true",
                         help="Back up all files which get changed to a copy with .bak added to the name")
     parser.add_argument("-t", "--tmpl", dest="tmpl", default=None,
                         help="Template name or file to use.")
@@ -246,7 +247,7 @@ def parse_command_line(argv):
     loglevel = max(4 - arguments.verbose_count, 1) * 10
     LOGGER.setLevel(loglevel)
     if arguments.D:
-      LOGGER.setLevel(logging.DEBUG)
+        LOGGER.setLevel(logging.DEBUG)
     return arguments
 
 
@@ -357,7 +358,7 @@ def read_file(file, args):
     LOGGER.info("Processing file {} as {}".format(file, ftype))
     for line in lines:
         if i == 0 and keep_first and keep_first.findall(line):
-            skip = i+1
+            skip = i + 1
         elif emptyPattern.findall(line):
             pass
         elif block_comment_start_pattern and block_comment_start_pattern.findall(line):
@@ -383,8 +384,8 @@ def read_file(file, args):
                     "settings": settings,
                     "haveLicense": have_license
                     }
-        i = i+1
-    LOGGER.debug("Found preliminary start at {}, i={}, lines={}".format(head_start,i,len(lines)))
+        i = i + 1
+    LOGGER.debug("Found preliminary start at {}, i={}, lines={}".format(head_start, i, len(lines)))
     # now we have either reached the end, or we are at a line where a block start or line comment occurred
     # if we have reached the end, return default dictionary without info
     if i == len(lines):
@@ -441,7 +442,7 @@ def read_file(file, args):
                         "lines": lines,
                         "skip": skip,
                         "headStart": i,
-                        "headEnd": j-1,
+                        "headEnd": j - 1,
                         "yearsLine": years_line,
                         "settings": settings,
                         "haveLicense": have_license
@@ -456,7 +457,7 @@ def read_file(file, args):
                 "lines": lines,
                 "skip": skip,
                 "headStart": i,
-                "headEnd": len(lines)-1,
+                "headEnd": len(lines) - 1,
                 "yearsLine": years_line,
                 "settings": settings,
                 "haveLicense": have_license
@@ -471,8 +472,9 @@ def make_backup(file, arguments):
     :return:
     """
     if arguments.b:
-        LOGGER.info("Backing up file {} to {}".format(file, file+".bak"))
-        copyfile(file, file+".bak")
+        LOGGER.info("Backing up file {} to {}".format(file, file + ".bak"))
+        copyfile(file, file + ".bak")
+
 
 def main():
     """Main function."""
@@ -483,7 +485,7 @@ def main():
         exts = settings["extensions"]
         for ext in exts:
             ext2type[ext] = t
-            patterns.append("*"+ext)
+            patterns.append("*" + ext)
     try:
         error = False
         template_lines = None
@@ -547,15 +549,17 @@ def main():
             LOGGER.debug("Patterns: %s", patterns)
             paths = get_paths(patterns, start_dir)
             for file in paths:
-                LOGGER.debug("Processing file: %s", file)                
+                LOGGER.debug("Processing file: %s", file)
                 finfo = read_file(file, arguments)
                 if not finfo:
                     LOGGER.debug("File not supported %s", file)
                     continue
                 # logging.debug("FINFO for the file: %s", finfo)
                 lines = finfo["lines"]
-                LOGGER.debug("Info for the file: headStart=%s, headEnd=%s, haveLicense=%s, skip=%s, len=%s, yearsline=%s",
-                             finfo["headStart"], finfo["headEnd"], finfo["haveLicense"], finfo["skip"], len(lines), finfo["yearsLine"])
+                LOGGER.debug(
+                    "Info for the file: headStart=%s, headEnd=%s, haveLicense=%s, skip=%s, len=%s, yearsline=%s",
+                    finfo["headStart"], finfo["headEnd"], finfo["haveLicense"], finfo["skip"], len(lines),
+                    finfo["yearsLine"])
                 # if we have a template: replace or add
                 if template_lines:
                     make_backup(file, arguments)
@@ -574,9 +578,9 @@ def main():
                             #  now write the new header from the template lines
                             fw.writelines(for_type(template_lines, ftype))
                             #  now write the rest of the lines
-                            fw.writelines(lines[head_end+1:])
+                            fw.writelines(lines[head_end + 1:])
                         else:
-                            LOGGER.debug("Adding header to file {}, skip={}".format(file,skip))
+                            LOGGER.debug("Adding header to file {}, skip={}".format(file, skip))
                             fw.writelines(lines[0:skip])
                             fw.writelines(for_type(template_lines, ftype))
                             fw.writelines(lines[skip:])
@@ -590,7 +594,7 @@ def main():
                             LOGGER.debug("Updating years in file {} in line {}".format(file, years_line))
                             fw.writelines(lines[0:years_line])
                             fw.write(yearsPattern.sub(arguments.years, lines[years_line]))
-                            fw.writelines(lines[years_line+1:])
+                            fw.writelines(lines[years_line + 1:])
                         # TODO: optionally remove backup if all worked well
     finally:
         logging.shutdown()

--- a/licenseheaders.py
+++ b/licenseheaders.py
@@ -229,7 +229,7 @@ def parse_command_line(argv):
         {1} -y 2012-2015   
         {1} -y 2012-2015 -d /dir/where/to/start/   
         {1} -y 2012-2015 -d /dir/where/to/start/ --additional-extensions python=.j2
-        {1} -y 2012-2015 -d /dir/where/to/start/ --additional-extensions python=.j2,.tpl script=.txt,
+        {1} -y 2012-2015 -d /dir/where/to/start/ --additional-extensions python=.j2,.tpl script=.txt
       See: https://github.com/johann-petrak/licenseheaders
     """).format(known_extensions, os.path.basename(argv[0]))
     formatter_class = argparse.RawDescriptionHelpFormatter
@@ -262,8 +262,8 @@ def parse_command_line(argv):
                         help="Do not raise error if template variables cannot be substituted.")
     parser.add_argument("-D", action="store_true", help="Enable debug messages (same as -v -v -v)")
     parser.add_argument("--additional-extensions", dest="additional_extensions", default=None, nargs="+",
-                        help="Provide a comma-separated list of additional file extensions for "
-                             "specified languages each with a leading dot and no whitespace (default: None).",
+                        help="Provide a comma-separated list of additional file extensions as value for a "
+                             "specified language as key, each with a leading dot and no whitespace (default: None).",
                         action=DictArgs)
     arguments = parser.parse_args(argv[1:])
 


### PR DESCRIPTION
Hello,

this tool is limited to work for the built-in file extensions only which are declared in a python datastructure.

I wrote a PR to introduce the ability to apply license headers to a broader variety of file extensions.
I also executed auto-formatting in an extra (first) commit.
Docs were updated too.

Currently this tool does not support multiple dots (".") in a single file extension, I noted this in the README and this could be a new upcoming feature to provide more flexibility for projects using this tool.

I also think it should be considered using the `global` keyword for global var usage inside functions.