### PR TITLE
Fixed Apache-2 license template

### DIFF
--- a/templates/apache-2.tmpl
+++ b/templates/apache-2.tmpl
@@ -1,21 +1,16 @@
 Copyright (c) ${years} ${owner}.
 
-This file is part of ${projectname}
-(see ${projecturl}).
+This file is part of ${projectname}.
+See ${projecturl} for further info.
 
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
The original template was mentioning `Licensed *to* the Apache Software Foundation`. This is clearly not the intention when you use the license. The new text is copied verbatim from the [URL indicated as reference](http://www.apache.org/licenses/LICENSE-2.0).