### PR TITLE
Fix for ruby extension

### DIFF
--- a/licenseheaders.py
+++ b/licenseheaders.py
@@ -139,7 +139,7 @@ typeSettings = {
     },
     "ruby": {
         "extensions": [".rb"],
-        "keepFirst": "^#!",
+        "keepFirst": re.compile(r'^#!'),
         "blockCommentStartPattern": re.compile('^=begin'),
         "blockCommentEndPattern": re.compile(r'^=end'),
         "lineCommentStartPattern": re.compile(r'\s*#'),


### PR DESCRIPTION
There is an exception: 

  File licenseheaders.py", line 695, in main
    finfo = read_file(file, arguments)
  File licenseheaders.py", line 468, in read_file
    if i == 0 and keep_first and keep_first.findall(line):
AttributeError: 'str' object has no attribute 'findall'