### PR TITLE
Add support for read-only files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ optional arguments:
 Known extensions: ['java:.java,.scala,.groovy,.jape,.js', 'script:.sh,.csh,.py,.pl', 'perl:.pl', 'python:.py', 'robot:.robot', 'xml:.xml', 'sql:.sql', 'c:.c,.cc,.cpp,c++,.h,.hpp', 'ruby:.rb', 'csharp:.cs', 'vb:.vb', 'erlang:.erl,.src,.config,.schema', 'html:.html', 'css:.css,.scss,.sass', 'docker:.dockerfile', 'yaml:.yaml,.yml', 'zig:.zig']
 
 If -t/--tmpl is specified, that header is added to (or existing header replaced for) all source files of known type
-If -t/--tmpl is not specified byt -y/--years is specified, all years in existing header files
+If -t/--tmpl is not specified but -y/--years is specified, all years in existing header files
   are replaced with the years specified
 
 Examples:

--- a/licenseheaders.py
+++ b/licenseheaders.py
@@ -28,6 +28,8 @@ import fnmatch
 import logging
 import os
 import sys
+import stat
+import contextlib
 from shutil import copyfile
 from string import Template
 
@@ -407,7 +409,7 @@ def parse_command_line(argv):
     parser.add_argument("--safesubst", action="store_true",
                         help="Do not raise error if template variables cannot be substituted.")
     parser.add_argument("-D", "--debug", action="store_true", help="Enable debug messages (same as -v -v -v)")
-    parser.add_argument("-E","--ext", type=str, nargs="*",  
+    parser.add_argument("-E","--ext", type=str, nargs="*",
                         help="If specified, restrict processing to the specified extension(s) only")
     parser.add_argument("--additional-extensions", dest="additional_extensions", default=None, nargs="+",
                         help="Provide a comma-separated list of additional file extensions as value for a "
@@ -415,6 +417,9 @@ def parse_command_line(argv):
                         action=DictArgs)
     parser.add_argument("-x", "--exclude", type=str, nargs="*",
                         help="File path patterns to exclude")
+    parser.add_argument("--force-overwrite", action="store_true", dest="force_overwrite",
+                        help="Try to include headers even in read-only files, given sufficient permissions. "
+                             "File permissions are restored after successful header injection.")
     arguments = parser.parse_args(argv[1:])
 
     # Sets log level to WARN going more verbose for each new -V.
@@ -438,27 +443,27 @@ def read_type_settings(path):
             setting[name] = re.compile(setting[name])
         else:
             setting[name] = None
-            
+
     def handle_line(setting, name):
         if setting[name]:
             setting[name] = setting[name]
         else:
             setting[name] = None
-        
+
     settings = {}
-    
+
     import json
     with open(path) as f:
         data = json.load(f)
     for key, value in data.items():
         for setting_name in ["keepFirst", "blockCommentStartPattern", "blockCommentEndPattern", "lineCommentStartPattern", "lineCommentEndPattern"]:
             handle_regex(value, setting_name)
-     
+
         for setting_name in ["headerStartLine", "headerEndLine", "headerLinePrefix", "headerLineSuffix"]:
             handle_line(value, setting_name)
 
         settings[key] = value
-      
+
     return settings
 
 def get_paths(fnpatterns, start_dir=default_dir):
@@ -479,7 +484,7 @@ def get_paths(fnpatterns, start_dir=default_dir):
                 continue
             seen.add(path)
             yield path
-            
+
 def get_files(fnpatterns, files):
     seen = set()
     names = []
@@ -488,7 +493,7 @@ def get_files(fnpatterns, files):
         for pattern in fnpatterns:
             if fnmatch.filter([file_name], pattern):
                 names += [f]
-                
+
     for path in names:
         if path in seen:
             continue
@@ -573,6 +578,8 @@ def read_file(file, args, type_settings):
         if not ftype:
             return None
     settings = type_settings.get(ftype)
+    if not os.access(file, os.R_OK):
+        LOGGER.error("File %s is not readable.", file)
     with open(file, 'r', encoding=args.encoding) as f:
         lines = f.readlines()
     # now iterate throw the lines and try to determine the various indies
@@ -706,17 +713,98 @@ def make_backup(file, arguments):
             copyfile(file, file + ".bak")
 
 
+class OpenAsWriteable(object):
+    """
+    This contextmanager wraps standard open(file, 'w', encoding=...) using
+    arguments.encoding encoding. If file cannot be written (read-only file),
+    and if args.force_overwrite is set, try to alter the owner write flag before
+    yielding the file handle. On exit, file permissions are restored to original
+    permissions on __exit__ . If the file does not exist, or if it is read-only
+    and cannot be made writeable (due to lacking user rights or force_overwrite
+    argument not being set), this contextmanager yields None on __enter__.
+    """
+
+    def __init__(self, filename, arguments):
+        """
+        Initialize an OpenAsWriteable context manager
+        :param filename: path to the file to open
+        :param arguments: program arguments
+        """
+        self._filename  = filename
+        self._arguments = arguments
+        self._file_handle = None
+        self._file_permissions = None
+
+    def __enter__(self):
+        """
+        Yields a writeable file handle when possible, else None.
+        """
+        filename = self._filename
+        arguments = self._arguments
+        file_handle = None
+        file_permissions = None
+
+        if os.path.isfile(filename):
+            file_permissions = stat.S_IMODE(os.lstat(filename).st_mode)
+
+            if not os.access(filename, os.W_OK):
+                if arguments.force_overwrite:
+                    try:
+                        os.chmod(filename, file_permissions | stat.S_IWUSR)
+                    except PermissionError:
+                        LOGGER.warning("File {} cannot be made writeable, it will be skipped.".format(filename))
+                else:
+                    LOGGER.warning("File {} is not writeable, it will be skipped.".format(filename))
+
+            if os.access(filename, os.W_OK):
+                file_handle = open(filename, 'w', encoding=arguments.encoding)
+        else:
+            LOGGER.warning("File {} does not exist, it will be skipped.".format(filename))
+
+        self._file_handle = file_handle
+        self._file_permissions = file_permissions
+
+        return file_handle
+
+    def __exit__ (self, exc_type, exc_value, traceback):
+        """
+        Restore back file permissions and close file handle (if any).
+        """
+        if (self._file_handle is not None):
+            self._file_handle.close()
+
+            actual_permissions = stat.S_IMODE(os.lstat(self._filename).st_mode)
+            if (actual_permissions != self._file_permissions):
+                try:
+                    os.chmod(self._filename, self._file_permissions)
+                except PermissionError:
+                    LOGGER.error("File {} permissions could not be restored.".format(self._filename))
+
+            self._file_handle = None
+            self._file_permissions = None
+        return True
+
+
+@contextlib.contextmanager
+def open_as_writeable(file, arguments):
+    """
+    Wrapper around OpenAsWriteable context manager.
+    """
+    with OpenAsWriteable(file, arguments=arguments) as fw:
+        yield fw
+
+
 def main():
     """Main function."""
     # LOGGER.addHandler(logging.StreamHandler(stream=sys.stderr))
     # init: create the ext2type mappings
     arguments = parse_command_line(sys.argv)
     additional_extensions = arguments.additional_extensions
-    
+
     type_settings = TYPE_SETTINGS
     if arguments.settings:
         type_settings = read_type_settings(arguments.settings)
-    
+
     for t in type_settings:
         settings = type_settings[t]
         exts = settings["extensions"]
@@ -750,7 +838,7 @@ def main():
         if arguments.dir is not default_dir and arguments.files:
             LOGGER.error("Cannot use both '--dir' and '--files' options.")
             error = True
-            
+
         if arguments.years and arguments.current_year:
             LOGGER.error("Cannot use both '--years' and '--currentyear' options.")
             error = True
@@ -760,7 +848,7 @@ def main():
             import datetime
             now = datetime.datetime.now()
             years = str(now.year)
-        
+
         settings = {}
         if years:
             settings["years"] = years
@@ -825,7 +913,7 @@ def main():
                 LOGGER.debug("Processing directory %s", arguments.dir)
                 LOGGER.debug("Patterns: %s", patterns)
                 paths = get_paths(patterns, arguments.dir)
-                
+
             for file in paths:
                 LOGGER.debug("Considering file: {}".format(file))
                 file = os.path.normpath(file)
@@ -851,7 +939,7 @@ def main():
                     if arguments.dry:
                         LOGGER.info("Would be updating changed file: {}".format(file))
                     else:
-                        with open(file, 'w', encoding=arguments.encoding) as fw:
+                        with open_as_writeable(file, arguments) as fw:
                             # if we found a header, replace it
                             # otherwise, add it after the lines to skip
                             head_start = finfo["headStart"]
@@ -872,7 +960,7 @@ def main():
                                 fw.writelines(lines[0:skip])
                                 fw.writelines(for_type(template_lines, ftype, type_settings))
                                 if head_start is not None and not have_license:
-                                    # There is some header, but not license - add an empty line 
+                                    # There is some header, but not license - add an empty line
                                     fw.write("\n")
                                 fw.writelines(lines[skip:])
                         # TODO: optionally remove backup if all worked well?
@@ -884,7 +972,7 @@ def main():
                         if arguments.dry:
                             LOGGER.info("Would be updating year line in file {}".format(file))
                         else:
-                            with open(file, 'w', encoding=arguments.encoding) as fw:
+                            with open_as_writeable(file, arguments) as fw:
                                 LOGGER.debug("Updating years in file {} in line {}".format(file, years_line))
                                 fw.writelines(lines[0:years_line])
                                 fw.write(yearsPattern.sub(years, lines[years_line]))

--- a/tests/driver.py
+++ b/tests/driver.py
@@ -1,25 +1,32 @@
 import os
-import shutil 
-import subprocess 
+import stat
+import shutil
+import subprocess
 import sys
 
-def run_file(licenseheaders_path, file_path):
+def run_file(licenseheaders_path, file_path, extra_args=None):
+    if (extra_args is None):
+        extra_args = []
     subprocess.check_call(
-        [sys.executable, licenseheaders_path, 
-        "-t", "lgpl-v3", 
+        [sys.executable, licenseheaders_path,
+        "-t", "lgpl-v3",
         "-y", "2012-2014",
         "-o", "ThisNiceCompany",
         "-n", "ProjectName",
-        "-u", "http://the.projectname.com", 
-        "-f", file_path]
+        "-u", "http://the.projectname.com",
+        "-f", file_path] + extra_args
     )
-    
+
 def compare_files(file_name, result_file_path, expected_file_path):
     with open(result_file_path) as f1, open(expected_file_path) as f2:
         for line1, line2 in zip(f1, f2):
             if line1 != line2:
                 print(f"File {file_name} content is different from expected")
                 return 1
+    result_file_permissions = stat.S_IMODE(os.lstat(result_file_path).st_mode)
+    expected_file_permissions = stat.S_IMODE(os.lstat(expected_file_path).st_mode)
+    if (result_file_permissions != expected_file_permissions):
+        return 1
     return 0
 
 def main():
@@ -28,18 +35,28 @@ def main():
     result_dir = "result"
     licenseheaders_path = "../licenseheaders.py"
     differences = 0
-    
+
+    if not os.path.exists(result_dir):
+        os.makedirs(result_dir)
+
     file_names = [f for f in os.listdir(input_dir) if os.path.isfile(os.path.join(input_dir, f))]
     for file_name in file_names:
         input_file_path = os.path.join(input_dir, file_name)
         expected_file_path = os.path.join(expected_dir, file_name)
         result_file_path = os.path.join(result_dir, file_name)
-        
+
         shutil.copyfile(input_file_path, result_file_path)
-        run_file(licenseheaders_path, result_file_path)
+
+        extra_args = []
+        if not os.access(result_file_path, os.W_OK):
+            extra_args += ['--force-overwrite']
+
         # Run it twice for identifying of removed comments
-        run_file(licenseheaders_path, result_file_path)
+        run_file(licenseheaders_path, result_file_path, extra_args)
+        run_file(licenseheaders_path, result_file_path, extra_args)
+
         differences += compare_files(file_name, result_file_path, expected_file_path)
+
     if differences:
         return 1
     else:

--- a/tests/expected/CMakeLists.txt
+++ b/tests/expected/CMakeLists.txt
@@ -1,25 +1,22 @@
-##
-## Copyright (c) 2012-2014 ThisNiceCompany.
-##
-## This file is part of ProjectName 
-## (see http://the.projectname.com).
-##
-## This program is free software: you can redistribute it and/or modify
-## it under the terms of the GNU Lesser General Public License as published by
-## the Free Software Foundation, either version 3 of the License, or
-## (at your option) any later version.
-##
-## This program is distributed in the hope that it will be useful,
-## but WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-## GNU Lesser General Public License for more details.
-##
-## You should have received a copy of the GNU Lesser General Public License
-## along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+#[[
+Copyright (c) 2012-2014 ThisNiceCompany.
 
-# Don't remove me
-cmake_minimum_required (VERSION 3.12 FATAL_ERROR) # 3.12 is mandatory since we rely on NEW behaviour for CMP0074
+This file is part of ProjectName 
+(see http://the.projectname.com).
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+]]
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.0")
   cmake_policy(SET CMP0077 OLD) # option() honors normal behaviour. This was introduced in CMake 3.13.
                                 # Use the old policy to retain compatability with 3.12.

--- a/tests/expected/test.sh
+++ b/tests/expected/test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+##
+## Copyright (c) 2012-2014 ThisNiceCompany.
+##
+## This file is part of ProjectName 
+## (see http://the.projectname.com).
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this program. If not, see <http://www.gnu.org/licenses/>.
+##
+
+echo "Test with read-only file"
+exit 0

--- a/tests/input/test.sh
+++ b/tests/input/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Test with read-only file"
+exit 0


### PR DESCRIPTION
This pull request adds support for read-only files. 
Currently, licenceheaders crashes when input files are not readable or not writable.
This patch makes licenceheaders ignore read-only files (with a warning) as the new default behavior.

Moreover, it adds a new argument `--force-overwrite` to tell licenceheaders to try to change file permissions prior to license injection (i.e. make read-only files writable). On success everything works as expected and file permission are restored afterwards. On failure (insufficient file permissions), the file is ignored with a warning.

This patch also fixes the following:
- Log an error when the file is not readable, prior to crash
- Fix CMakelists.txt test case
- Adds read-only test.sh test case
- Add file permission comparison to tests validation
- Fix a small typo in README.md

Files that are not readable are not affected by this patch, besides additional logs.

This is a proposal to fix issue #55.