### PR TITLE
Allow for empty lines in line comment start

### DIFF
--- a/licenseheaders.py
+++ b/licenseheaders.py
@@ -106,7 +106,7 @@ TYPE_SETTINGS = {
         "keepFirst": re.compile(r'^#!|^# +pylint|^# +-\*-|^# +coding|^# +encoding|^# +type|^# +flake8'),
         "blockCommentStartPattern": None,
         "blockCommentEndPattern": None,
-        "lineCommentStartPattern": re.compile(r'^\s*#'),
+        "lineCommentStartPattern": re.compile(r'^(\s*#|$)'),
         "lineCommentEndPattern": None,
         "headerStartLine": "#\n",
         "headerEndLine": "#\n",


### PR DESCRIPTION
In my python code the license header is currently like this:

```python
# This file is part of frestq.
# Copyright (C) 2013-2020  Agora Voting SL <contact@nvotes.com>

# frestq is free software: you can redistribute it and/or modify
# it under the terms of the GNU Lesser General Public License as published by
# the Free Software Foundation, either version 3 of the License.

# frestq  is distributed in the hope that it will be useful,
# but WITHOUT ANY WARRANTY; without even the implied warranty of
# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
# GNU Lesser General Public License for more details.

# You should have received a copy of the GNU Lesser General Public License
# along with frestq.  If not, see <http://www.gnu.org/licenses/>.
```

Instead of

```python
#
# This file is part of frestq.
# Copyright (C) 2013-2020  Agora Voting SL <contact@nvotes.com>
#
# frestq is free software: you can redistribute it and/or modify
# it under the terms of the GNU Lesser General Public License as published by
# the Free Software Foundation, either version 3 of the License.
#
# frestq  is distributed in the hope that it will be useful,
# but WITHOUT ANY WARRANTY; without even the implied warranty of
# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
# GNU Lesser General Public License for more details.
#
# You should have received a copy of the GNU Lesser General Public License
# along with frestq.  If not, see <http://www.gnu.org/licenses/>.
#
```

Currently this is not rightly matched by `licenseheaders`. A simple change in the `lineCommentStartPattern` solves this.