### PR TITLE
Fix start and end line settings for Python

### DIFF
--- a/licenseheaders.py
+++ b/licenseheaders.py
@@ -108,8 +108,8 @@ TYPE_SETTINGS = {
         "blockCommentEndPattern": None,
         "lineCommentStartPattern": re.compile(r'^\s*#'),
         "lineCommentEndPattern": None,
-        "headerStartLine": "#\n",
-        "headerEndLine": "#\n",
+        "headerStartLine": None,
+        "headerEndLine": "\n",
         "headerLinePrefix": "# ",
         "headerLineSuffix": None
     },


### PR DESCRIPTION
Removes the redundant leading and trailing `#` from the header. 