### PR TITLE
Log and ignore when meet unknown encoding file

### DIFF
--- a/licenseheaders.py
+++ b/licenseheaders.py
@@ -428,7 +428,7 @@ def parse_command_line(argv):
                              "File permissions are restored after successful header injection.")
     arguments = parser.parse_args(argv[1:])
 
-    # Sets log level to WARN going more verbose for each new -V.
+    # Sets log level to WARN going more verbose for each new -v.
     loglevel = max(4 - arguments.verbose_count, 1) * 10
     global LOGGER
     LOGGER.setLevel(loglevel)
@@ -802,7 +802,6 @@ def open_as_writable(file, arguments):
 
 def main():
     """Main function."""
-    # LOGGER.addHandler(logging.StreamHandler(stream=sys.stderr))
     # init: create the ext2type mappings
     arguments = parse_command_line(sys.argv)
     additional_extensions = arguments.additional_extensions
@@ -929,7 +928,11 @@ def main():
                 if arguments.exclude and any([fnmatch.fnmatch(file, pat) for pat in arguments.exclude]):
                     LOGGER.info("Ignoring file {}".format(file))
                     continue
-                finfo = read_file(file, arguments, type_settings)
+                try:
+                    finfo = read_file(file, arguments, type_settings)
+                except Exception as e:
+                    LOGGER.error("Exceptions when reading file %s, error=%s", file, e)
+                    finfo = None
                 if not finfo:
                     LOGGER.debug("File not supported %s", file)
                     continue


### PR DESCRIPTION
First of all, thanks for this fantastic script!

When using this script to handle my codes, the script exit with an exception. I think it is better to log an error and continue for other files in the directory.

I've tested it as follows
```
>  python3 licenseheaders.py -t templates/apache-2.tmpl -y 2023 -o 'JaySon' -d tests -vv
licenseheaders_0.8.8 INFO: Using file /Users/jayson/Projects/licenseheaders/templates/apache-2.tmpl
licenseheaders_0.8.8 INFO: Processing file tests/driver.py as python
licenseheaders_0.8.8 INFO: Processing file tests/expected/test.h as c
licenseheaders_0.8.8 INFO: Processing file tests/expected/test.cpp as cpp
licenseheaders_0.8.8 INFO: Processing file tests/expected/test.sh as script
licenseheaders_0.8.8 INFO: Processing file tests/expected/test.py as python
licenseheaders_0.8.8 INFO: Processing file tests/expected/CMakeLists.txt as cmake
licenseheaders_0.8.8 INFO: Processing file tests/expected/test.v as ocaml
licenseheaders_0.8.8 ERROR: Exceptions when reading file tests/input/shark0.cc, error='utf-8' codec can't decode byte 0xff in position 0: invalid start byte
licenseheaders_0.8.8 INFO: Processing file tests/input/test.h as c
licenseheaders_0.8.8 INFO: Processing file tests/input/test.cpp as cpp
licenseheaders_0.8.8 INFO: Processing file tests/input/test.sh as script
licenseheaders_0.8.8 INFO: Processing file tests/input/test.py as python
licenseheaders_0.8.8 INFO: Processing file tests/input/CMakeLists.txt as cmake
licenseheaders_0.8.8 INFO: Processing file tests/input/test.v as ocaml
```